### PR TITLE
Fixed #65 - MD002 warning message for valid links with fragments

### DIFF
--- a/src/Validation/UrlValidator.cs
+++ b/src/Validation/UrlValidator.cs
@@ -1,5 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations.Schema;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using Markdig.Syntax.Inlines;
@@ -94,7 +93,7 @@ namespace MarkdownEditor2022.Validation
             }
 
             /// <summary>
-            /// If a '#' is found then returns everything up to that index.
+            /// If a '#' is found then returns true and processed is everything from the start up to but not including the '#'.
             /// </summary>
             static bool TryStripFragmentFromPath(string input, out string processed)
             {


### PR DESCRIPTION
Unfortunately, this is untested.  I don't have the Microsoft.mshtml, Version=7.0.3300.0 dependency.
I tested the method that strips fragments separately.