### PR TITLE
Add distinct classifications for Markdown headers (H1-H6)

### DIFF
--- a/src/Editor/ClassificationTypes.cs
+++ b/src/Editor/ClassificationTypes.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.Composition;
+using System.ComponentModel.Composition;
 using System.Windows;
 using System.Windows.Media;
 using Microsoft.VisualStudio.Language.StandardClassification;
@@ -12,7 +12,12 @@ namespace MarkdownEditor2022
         public const string MarkdownBold = "md_bold";
         public const string MarkdownItalic = "md_italic";
         public const string MarkdownStrikethrough = "md_strikethrough";
-        public const string MarkdownHeader = "md_header";
+        public const string MarkdownHeader1 = "md_header1";
+        public const string MarkdownHeader2 = "md_header2";
+        public const string MarkdownHeader3 = "md_header3";
+        public const string MarkdownHeader4 = "md_header4";
+        public const string MarkdownHeader5 = "md_header5";
+        public const string MarkdownHeader6 = "md_header6";
         public const string MarkdownCode = "md_code";
         public const string MarkdownQuote = "md_quote";
         public const string MarkdownHtml = "md_html";
@@ -31,9 +36,29 @@ namespace MarkdownEditor2022
         [BaseDefinition(PredefinedClassificationTypeNames.Text)]
         public static ClassificationTypeDefinition MarkdownClassificationStrikethrough { get; set; }
 
-        [Export, Name(MarkdownHeader)]
+        [Export, Name(MarkdownHeader1)]
         [BaseDefinition(PredefinedClassificationTypeNames.SymbolDefinition)]
-        public static ClassificationTypeDefinition MarkdownClassificationHeader { get; set; }
+        public static ClassificationTypeDefinition MarkdownClassificationHeader1 { get; set; }
+
+        [Export, Name(MarkdownHeader2)]
+        [BaseDefinition(PredefinedClassificationTypeNames.SymbolDefinition)]
+        public static ClassificationTypeDefinition MarkdownClassificationHeader2 { get; set; }
+
+        [Export, Name(MarkdownHeader3)]
+        [BaseDefinition(PredefinedClassificationTypeNames.SymbolDefinition)]
+        public static ClassificationTypeDefinition MarkdownClassificationHeader3 { get; set; }
+
+        [Export, Name(MarkdownHeader4)]
+        [BaseDefinition(PredefinedClassificationTypeNames.SymbolDefinition)]
+        public static ClassificationTypeDefinition MarkdownClassificationHeader4 { get; set; }
+
+        [Export, Name(MarkdownHeader5)]
+        [BaseDefinition(PredefinedClassificationTypeNames.SymbolDefinition)]
+        public static ClassificationTypeDefinition MarkdownClassificationHeader5 { get; set; }
+
+        [Export, Name(MarkdownHeader6)]
+        [BaseDefinition(PredefinedClassificationTypeNames.SymbolDefinition)]
+        public static ClassificationTypeDefinition MarkdownClassificationHeader6 { get; set; }
 
         [Export, Name(MarkdownCode)]
         [BaseDefinition(PredefinedClassificationTypeNames.Text)]
@@ -92,15 +117,86 @@ namespace MarkdownEditor2022
     }
 
     [Export(typeof(EditorFormatDefinition))]
-    [ClassificationType(ClassificationTypeNames = ClassificationTypes.MarkdownHeader)]
-    [Name(ClassificationTypes.MarkdownHeader)]
+    [ClassificationType(ClassificationTypeNames = ClassificationTypes.MarkdownHeader1)]
+    [Name(ClassificationTypes.MarkdownHeader1)]
     [UserVisible(true)]
-    internal sealed class MarkdownHeaderFormatDefinition : ClassificationFormatDefinition
+    internal sealed class MarkdownHeader1FormatDefinition : ClassificationFormatDefinition
     {
-        public MarkdownHeaderFormatDefinition()
+        public MarkdownHeader1FormatDefinition()
         {
             IsBold = true;
-            DisplayName = "Markdown Header";
+            DisplayName = "Markdown Header 1";
+            ForegroundColor = Color.FromRgb(0x00, 0x80, 0xFF);
+        }
+    }
+
+    [Export(typeof(EditorFormatDefinition))]
+    [ClassificationType(ClassificationTypeNames = ClassificationTypes.MarkdownHeader2)]
+    [Name(ClassificationTypes.MarkdownHeader2)]
+    [UserVisible(true)]
+    internal sealed class MarkdownHeader2FormatDefinition : ClassificationFormatDefinition
+    {
+        public MarkdownHeader2FormatDefinition()
+        {
+            IsBold = true;
+            DisplayName = "Markdown Header 2";
+            ForegroundColor = Color.FromRgb(0xFD, 0x04, 0xDC);
+        }
+    }
+
+    [Export(typeof(EditorFormatDefinition))]
+    [ClassificationType(ClassificationTypeNames = ClassificationTypes.MarkdownHeader3)]
+    [Name(ClassificationTypes.MarkdownHeader3)]
+    [UserVisible(true)]
+    internal sealed class MarkdownHeader3FormatDefinition : ClassificationFormatDefinition
+    {
+        public MarkdownHeader3FormatDefinition()
+        {
+            IsBold = true;
+            DisplayName = "Markdown Header 3";
+            ForegroundColor = Color.FromRgb(0xFF, 0x99, 0x00);
+        }
+    }
+
+    [Export(typeof(EditorFormatDefinition))]
+    [ClassificationType(ClassificationTypeNames = ClassificationTypes.MarkdownHeader4)]
+    [Name(ClassificationTypes.MarkdownHeader4)]
+    [UserVisible(true)]
+    internal sealed class MarkdownHeader4FormatDefinition : ClassificationFormatDefinition
+    {
+        public MarkdownHeader4FormatDefinition()
+        {
+            IsBold = true;
+            DisplayName = "Markdown Header 4";
+            ForegroundColor = Color.FromRgb(0xFF, 0x00, 0x00);
+        }
+    }
+
+    [Export(typeof(EditorFormatDefinition))]
+    [ClassificationType(ClassificationTypeNames = ClassificationTypes.MarkdownHeader5)]
+    [Name(ClassificationTypes.MarkdownHeader5)]
+    [UserVisible(true)]
+    internal sealed class MarkdownHeader5FormatDefinition : ClassificationFormatDefinition
+    {
+        public MarkdownHeader5FormatDefinition()
+        {
+            IsBold = true;
+            DisplayName = "Markdown Header 5";
+            ForegroundColor = Color.FromRgb(0x00, 0xFF, 0x00);
+        }
+    }
+
+    [Export(typeof(EditorFormatDefinition))]
+    [ClassificationType(ClassificationTypeNames = ClassificationTypes.MarkdownHeader6)]
+    [Name(ClassificationTypes.MarkdownHeader6)]
+    [UserVisible(true)]
+    internal sealed class MarkdownHeader6FormatDefinition : ClassificationFormatDefinition
+    {
+        public MarkdownHeader6FormatDefinition()
+        {
+            IsBold = true;
+            DisplayName = "Markdown Header 6";
+            ForegroundColor = Color.FromRgb(0xFF, 0xFF, 0x00);
         }
     }
 

--- a/src/Editor/EditorFeatures.cs
+++ b/src/Editor/EditorFeatures.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -23,7 +23,12 @@ namespace MarkdownEditor2022
     {
         public override Dictionary<object, string> ClassificationMap { get; } = new()
         {
-            { ClassificationTypes.MarkdownHeader, ClassificationTypes.MarkdownHeader },
+            { ClassificationTypes.MarkdownHeader1, ClassificationTypes.MarkdownHeader1 },
+            { ClassificationTypes.MarkdownHeader2, ClassificationTypes.MarkdownHeader2 },
+            { ClassificationTypes.MarkdownHeader3, ClassificationTypes.MarkdownHeader3 },
+            { ClassificationTypes.MarkdownHeader4, ClassificationTypes.MarkdownHeader4 },
+            { ClassificationTypes.MarkdownHeader5, ClassificationTypes.MarkdownHeader5 },
+            { ClassificationTypes.MarkdownHeader6, ClassificationTypes.MarkdownHeader6 },
             { ClassificationTypes.MarkdownCode, ClassificationTypes.MarkdownCode },
             { ClassificationTypes.MarkdownHtml, ClassificationTypes.MarkdownHtml },
             { ClassificationTypes.MarkdownComment, ClassificationTypes.MarkdownComment },

--- a/src/Editor/TokenTagger.cs
+++ b/src/Editor/TokenTagger.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading.Tasks;
@@ -83,7 +83,24 @@ namespace MarkdownEditor2022
             IEnumerable<ErrorListItem> errors = item.GetErrors(_document.FileName);
 
             SnapshotSpan span = new(Buffer.CurrentSnapshot, GetApplicableSpan(item));
-            TokenTag tag = CreateToken(GetItemType(item), true, supportsOutlining, errors);
+            
+            // Special handling for HeadingBlock to differentiate levels
+            string tokenType = GetItemType(item);
+            if (item is HeadingBlock headingBlock)
+            {
+                tokenType = headingBlock.Level switch
+                {
+                    1 => ClassificationTypes.MarkdownHeader1,
+                    2 => ClassificationTypes.MarkdownHeader2,
+                    3 => ClassificationTypes.MarkdownHeader3,
+                    4 => ClassificationTypes.MarkdownHeader4,
+                    5 => ClassificationTypes.MarkdownHeader5,
+                    6 => ClassificationTypes.MarkdownHeader6,
+                    _ => ClassificationTypes.MarkdownHeader1
+                };
+            }
+
+            TokenTag tag = CreateToken(tokenType, true, supportsOutlining, errors);
 
             if (tag.TokenType != null)
             {
@@ -222,7 +239,16 @@ namespace MarkdownEditor2022
             return mdobj switch
             {
                 YamlFrontMatterBlock => null,
-                HeadingBlock => ClassificationTypes.MarkdownHeader,
+                HeadingBlock hb => hb.Level switch
+                {
+                    1 => ClassificationTypes.MarkdownHeader1,
+                    2 => ClassificationTypes.MarkdownHeader2,
+                    3 => ClassificationTypes.MarkdownHeader3,
+                    4 => ClassificationTypes.MarkdownHeader4,
+                    5 => ClassificationTypes.MarkdownHeader5,
+                    6 => ClassificationTypes.MarkdownHeader6,
+                    _ => ClassificationTypes.MarkdownHeader1
+                },
                 CodeBlock or CodeInline => ClassificationTypes.MarkdownCode,
                 QuoteBlock => ClassificationTypes.MarkdownQuote,
                 LinkInline => ClassificationTypes.MarkdownLink,


### PR DESCRIPTION
- Enhanced Markdown Editor by introducing separate classification types and formatting for each header level (H1-H6) to allow for different colors, styles, etc., at each header level.
- Updated `ClassificationTypes.cs` to define new classification types and format definitions with unique styles.
- Modified `EditorFeatures.cs` and `TokenTagger.cs` to handle syntax highlighting and token creation for each header level.
- Improved visual differentiation and granularity in header-level handling.