### PR TITLE
Fix document rendering with lots of mail: / mailto:

### DIFF
--- a/src/Margin/Browser.cs
+++ b/src/Margin/Browser.cs
@@ -96,13 +96,13 @@ namespace MarkdownEditor2022
 
         // Regex for resolving relative paths in HTML attributes to absolute file:// URLs
         // Matches src="...", href="...", and data="..." attributes with relative paths (not starting with http, https, data:, #, or /)
-        private static readonly Regex _relativePathRegex = new(
+        internal static readonly Regex _relativePathRegex = new(
             @"(?<attr>src|href|data)\s*=\s*""(?<path>(?!https?://|data:|#|/)[^""]+)""",
             RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
         // Regex for resolving root-relative paths (paths starting with /) in HTML attributes
         // Matches src="...", href="...", and data="..." attributes with paths starting with / (but not //)
-        private static readonly Regex _rootRelativePathRegex = new(
+        internal static readonly Regex _rootRelativePathRegex = new(
             @"(?<attr>src|href|data)\s*=\s*""(?<path>/(?!/)[^""]+)""",
             RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
 
@@ -1227,24 +1227,7 @@ namespace MarkdownEditor2022
 
                     try
                     {
-                        // Only decode if path contains encoded characters (avoid allocation otherwise)
-                        string decodedPath = relativePath.IndexOf('%') >= 0
-                            ? WebUtility.UrlDecode(relativePath)
-                            : relativePath;
-
-                        // Remove leading slash and normalize path separators
-                        string pathWithoutLeadingSlash = decodedPath.TrimStart('/');
-                        pathWithoutLeadingSlash = pathWithoutLeadingSlash.Replace('/', Path.DirectorySeparatorChar);
-
-                        // Resolve against the root path
-                        string fullPath = Path.GetFullPath(Path.Combine(rootPath, pathWithoutLeadingSlash));
-
-                        // Convert to virtual host URL relative to drive root
-                        string relativeToDrive = fullPath.StartsWith(driveRoot, StringComparison.OrdinalIgnoreCase)
-                            ? fullPath.Substring(driveRoot.Length)
-                            : fullPath;
-
-                        return string.Concat(attr, "=\"", _virtualHostUrlPrefix, relativeToDrive.Replace(Path.DirectorySeparatorChar, '/'), "\"");
+                        return ResolveRootRelativePath(attr, relativePath, rootPath, driveRoot);
                     }
                     catch
                     {
@@ -1260,32 +1243,15 @@ namespace MarkdownEditor2022
                 string attr = match.Groups["attr"].Value;
                 string relativePath = match.Groups["path"].Value;
 
-                // Skip if it's an anchor-only link or already absolute
-                if (string.IsNullOrEmpty(relativePath) || relativePath.StartsWith("#"))
+                // Skip if it's an anchor-only link, already absolute, or a URI scheme (mailto:, tel:, mail:, etc.)
+                if (string.IsNullOrEmpty(relativePath) || relativePath.StartsWith("#") || relativePath.IndexOf(':') >= 0)
                 {
                     return match.Value;
                 }
 
                 try
                 {
-                    // Only decode if path contains encoded characters (avoid allocation otherwise)
-                    string decodedPath = relativePath.IndexOf('%') >= 0
-                        ? WebUtility.UrlDecode(relativePath)
-                        : relativePath;
-
-                    // Normalize path separators
-                    decodedPath = decodedPath.Replace('/', Path.DirectorySeparatorChar);
-
-                    // Resolve the full path using Path.GetFullPath which handles ../ correctly
-                    string fullPath = Path.GetFullPath(Path.Combine(baseDirectory, decodedPath));
-
-                    // Convert to virtual host URL relative to drive root
-                    // e.g., C:\Projects\images\foo.png -> http://browsing-file-host/Projects/images/foo.png
-                    string relativeToDrive = fullPath.StartsWith(driveRoot, StringComparison.OrdinalIgnoreCase)
-                        ? fullPath.Substring(driveRoot.Length)
-                        : fullPath;
-
-                    return string.Concat(attr, "=\"", _virtualHostUrlPrefix, relativeToDrive.Replace(Path.DirectorySeparatorChar, '/'), "\"");
+                    return ResolveRelativePath(attr, relativePath, baseDirectory, driveRoot);
                 }
                 catch
                 {
@@ -1295,6 +1261,51 @@ namespace MarkdownEditor2022
             });
 
             return html;
+        }
+
+        /// <summary>Resolves a regular relative path to a virtual host URL attribute string.</summary>
+        internal static string ResolveRelativePath(string attr, string relativePath, string baseDirectory, string driveRoot)
+        {
+            string decodedPath = relativePath.IndexOf('%') >= 0
+                ? WebUtility.UrlDecode(relativePath)
+                : relativePath;
+
+            // Normalize path separators
+            decodedPath = decodedPath.Replace('/', Path.DirectorySeparatorChar);
+
+            // Resolve the full path using Path.GetFullPath which handles ../ correctly
+            string fullPath = Path.GetFullPath(Path.Combine(baseDirectory, decodedPath));
+
+            // Convert to virtual host URL relative to drive root
+            // e.g., C:\Projects\images\foo.png -> http://browsing-file-host/Projects/images/foo.png
+            string relativeToDrive = fullPath.StartsWith(driveRoot, StringComparison.OrdinalIgnoreCase)
+                ? fullPath.Substring(driveRoot.Length)
+                : fullPath;
+
+            return string.Concat(attr, "=\"", _virtualHostUrlPrefix, relativeToDrive.Replace(Path.DirectorySeparatorChar, '/'), "\"");
+        }
+
+        /// <summary>Resolves a root-relative path (starting with /) to a virtual host URL attribute string.</summary>
+        internal static string ResolveRootRelativePath(string attr, string relativePath, string rootPath, string driveRoot)
+        {
+            // Only decode if path contains encoded characters (avoid allocation otherwise)
+            string decodedPath = relativePath.IndexOf('%') >= 0
+                ? WebUtility.UrlDecode(relativePath)
+                : relativePath;
+
+            // Remove leading slash and normalize path separators
+            string pathWithoutLeadingSlash = decodedPath.TrimStart('/');
+            pathWithoutLeadingSlash = pathWithoutLeadingSlash.Replace('/', Path.DirectorySeparatorChar);
+
+            // Resolve against the root path
+            string fullPath = Path.GetFullPath(Path.Combine(rootPath, pathWithoutLeadingSlash));
+
+            // Convert to virtual host URL relative to drive root
+            string relativeToDrive = fullPath.StartsWith(driveRoot, StringComparison.OrdinalIgnoreCase)
+                ? fullPath.Substring(driveRoot.Length)
+                : fullPath;
+
+            return string.Concat(attr, "=\"", _virtualHostUrlPrefix, relativeToDrive.Replace(Path.DirectorySeparatorChar, '/'), "\"");
         }
 
         /// <summary>

--- a/test/MarkdownEditor2022.UnitTests/PathResolutionTests.cs
+++ b/test/MarkdownEditor2022.UnitTests/PathResolutionTests.cs
@@ -542,5 +542,76 @@ namespace MarkdownEditor2022.UnitTests
         }
 
         #endregion
+
+        #region URI Scheme Path Resolution Tests
+
+        /// <summary>
+        /// Exercises the relative-path resolution logic from Browser.cs WITHOUT the catch block,
+        /// so that guard omissions (e.g. missing URI-scheme check) surface as test failures
+        /// rather than being silently swallowed.
+        /// </summary>
+        private static string ResolveRelativePaths(string html, string baseDirectory)
+        {
+            string driveRoot = Path.GetPathRoot(baseDirectory);
+
+            return Browser._relativePathRegex.Replace(html, match =>
+            {
+                string attr = match.Groups["attr"].Value;
+                string relativePath = match.Groups["path"].Value;
+
+                if (string.IsNullOrEmpty(relativePath) || relativePath.StartsWith("#") || relativePath.IndexOf(':') >= 0)
+                    return match.Value;
+
+                return Browser.ResolveRelativePath(attr, relativePath, baseDirectory, driveRoot);
+            });
+        }
+
+        [TestMethod]
+        public void ResolveRelativePaths_MailtoLink_IsNotModified()
+        {
+            // Regression: href="mail:user@example.com" caused NotSupportedException
+            // because "mail:user@example.com" looks like a drive path on Windows.
+            string html = @"<a href=""mail:user@example.com"">Contact</a>";
+            string baseDir = @"C:\Projects\docs";
+
+            string result = ResolveRelativePaths(html, baseDir);
+
+            Assert.AreEqual(html, result, "mailto-style URI scheme links must not be modified.");
+        }
+
+        [TestMethod]
+        public void ResolveRelativePaths_TelLink_IsNotModified()
+        {
+            string html = @"<a href=""tel:+15551234567"">Call us</a>";
+            string baseDir = @"C:\Projects\docs";
+
+            string result = ResolveRelativePaths(html, baseDir);
+
+            Assert.AreEqual(html, result, "tel: URI scheme links must not be modified.");
+        }
+
+        [TestMethod]
+        public void ResolveRelativePaths_MailtoLink_IsNotModified2()
+        {
+            string html = @"<a href=""mailto:user@example.com"">Email</a>";
+            string baseDir = @"C:\Projects\docs";
+
+            string result = ResolveRelativePaths(html, baseDir);
+
+            Assert.AreEqual(html, result, "mailto: URI scheme links must not be modified.");
+        }
+
+        [TestMethod]
+        public void ResolveRelativePaths_NormalRelativePath_IsResolved()
+        {
+            string html = @"<img src=""images/photo.png"">";
+            string baseDir = @"C:\Projects\docs";
+
+            string result = ResolveRelativePaths(html, baseDir);
+
+            StringAssert.StartsWith(result, @"<img src=""http://browsing-file-host/");
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
I had a document with multiple mailto: / mail: that would refuse to render in the preview, like it was timing-out. Activating the CLR Exceptions, I found that there was an interpretation of those links by the browser to attempt to render the links that was time consuming.