### PR TITLE
Feature: add export to pdf command

### DIFF
--- a/src/Commands/ExportToPdfCommand.cs
+++ b/src/Commands/ExportToPdfCommand.cs
@@ -1,0 +1,62 @@
+using System.IO;
+using System.Windows.Forms;
+using MarkdownEditor2022.Services;
+
+namespace MarkdownEditor2022
+{
+    [Command(PackageIds.ExportToPdf)]
+    internal sealed class ExportToPdfCommand : BaseCommand<ExportToPdfCommand>
+    {
+        protected override Task InitializeCompletedAsync()
+        {
+            Command.Supported = false;
+            return base.InitializeCompletedAsync();
+        }
+
+        protected override async Task ExecuteAsync(OleMenuCmdEventArgs e)
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+            DocumentView docView = await VS.Documents.GetActiveDocumentViewAsync();
+            string markdownFile = docView?.FilePath;
+
+            if (!HtmlGenerationService.IsMarkdownFile(markdownFile))
+            {
+                await VS.StatusBar.ShowMessageAsync("Export to PDF is only available for Markdown files");
+                return;
+            }
+
+            string defaultName = Path.GetFileNameWithoutExtension(markdownFile) + ".pdf";
+            string outputPath;
+
+            using (SaveFileDialog dialog = new SaveFileDialog
+            {
+                Title = "Export Markdown to PDF",
+                Filter = "PDF files (*.pdf)|*.pdf",
+                FileName = defaultName,
+                InitialDirectory = Path.GetDirectoryName(markdownFile),
+                OverwritePrompt = true
+            })
+            {
+                if (dialog.ShowDialog() != DialogResult.OK)
+                {
+                    return;
+                }
+
+                outputPath = dialog.FileName;
+            }
+
+            try
+            {
+                await VS.StatusBar.ShowMessageAsync("Exporting to PDF…");
+                await PdfExportService.ExportToPdfAsync(markdownFile, outputPath);
+                await VS.StatusBar.ShowMessageAsync($"PDF exported: {Path.GetFileName(outputPath)}");
+            }
+            catch (Exception ex)
+            {
+                await VS.StatusBar.ShowMessageAsync($"PDF export failed: {ex.Message}");
+                await VS.MessageBox.ShowErrorAsync("Export to PDF", $"An error occurred while exporting to PDF:\n\n{ex.Message}");
+            }
+        }
+    }
+}

--- a/src/Margin/Browser.cs
+++ b/src/Margin/Browser.cs
@@ -389,7 +389,7 @@ namespace MarkdownEditor2022
         /// Adds the architecture-specific runtimes directory to the DLL search path so that
         /// WebView2Loader.dll can be found when packaged inside the VSIX under runtimes\win-{arch}\native\.
         /// </summary>
-        private static void EnsureNativeDllSearchPath()
+        internal static void EnsureNativeDllSearchPath()
         {
             if (_nativeDllSearchPathConfigured)
             {
@@ -1771,7 +1771,7 @@ namespace MarkdownEditor2022
         /// <summary>
         /// Gets or creates a cached WebView2 environment for faster initialization of subsequent browser instances.
         /// </summary>
-        private static Task<CoreWebView2Environment> GetOrCreateWebView2EnvironmentAsync()
+        internal static Task<CoreWebView2Environment> GetOrCreateWebView2EnvironmentAsync()
         {
             if (_cachedEnvironmentTask != null)
             {

--- a/src/MarkdownEditor2022.csproj
+++ b/src/MarkdownEditor2022.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
@@ -48,12 +48,14 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Commands\CommentCommand.cs" />
+    <Compile Include="Commands\ExportToPdfCommand.cs" />
     <Compile Include="Commands\EmphasizeTextCommand.cs" />
     <Compile Include="Commands\EnablePreviewSyncCommand.cs" />
     <Compile Include="Commands\FormatTableCommand.cs" />
     <Compile Include="Commands\GenerateTocCommand.cs" />
     <Compile Include="Commands\GenerateHtmlCommand.cs" />
     <Compile Include="Commands\HtmlGenerationService.cs" />
+    <Compile Include="Services\PdfExportService.cs" />
     <Compile Include="Commands\IndentationCommand.cs" />
     <Compile Include="Commands\InsertLinkCommand.cs" />
     <Compile Include="Commands\OpenSettingsCommand.cs" />

--- a/src/MarkdownEditor2022Package.cs
+++ b/src/MarkdownEditor2022Package.cs
@@ -76,6 +76,7 @@ namespace MarkdownEditor2022
             await MakeItalicCommand.InitializeAsync(this);
             await EnablePreviewSyncCommand.InitializeAsync(this);
             await GenerateHtmlCommand.InitializeAsync(this);
+            await ExportToPdfCommand.InitializeAsync(this);
             await GenerateTocCommand.InitializeAsync(this);
             await InsertLinkCommand.InitializeAsync(this);
             await OpenSettingsCommand.InitializeAsync(this);

--- a/src/Services/PdfExportService.cs
+++ b/src/Services/PdfExportService.cs
@@ -1,0 +1,106 @@
+using System.IO;
+using System.Threading.Tasks;
+using System.Windows;
+using Microsoft.Web.WebView2.Core;
+using Microsoft.Web.WebView2.Wpf;
+
+namespace MarkdownEditor2022.Services
+{
+    internal static class PdfExportService
+    {
+        /// <summary>
+        /// Converts the given Markdown file to PDF by rendering its HTML in a hidden WebView2 instance
+        /// and using the browser's built-in print-to-PDF capability.
+        /// </summary>
+        public static async Task ExportToPdfAsync(string markdownFile, string outputPdfPath)
+        {
+            if (string.IsNullOrWhiteSpace(markdownFile))
+            {
+                throw new ArgumentException("Markdown file path cannot be null or empty.", nameof(markdownFile));
+            }
+
+            if (string.IsNullOrWhiteSpace(outputPdfPath))
+            {
+                throw new ArgumentException("Output PDF path cannot be null or empty.", nameof(outputPdfPath));
+            }
+
+            string tempHtmlFile = null;
+            Window hiddenWindow = null;
+
+            try
+            {
+                // Build the HTML document from the markdown file
+                string html = HtmlGenerationService.BuildHtmlDocument(markdownFile);
+
+                // Write the HTML next to the markdown file so that WebView2 resolves relative
+                // resources (images, stylesheets, …) correctly via the same base directory.
+                string markdownDir = Path.GetDirectoryName(markdownFile);
+                tempHtmlFile = Path.Combine(markdownDir, $".export-{Guid.NewGuid():N}.html");
+                File.WriteAllText(tempHtmlFile, html, new System.Text.UTF8Encoding(true));
+
+                // All WebView2 interaction must happen on the UI thread
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+
+                Browser.EnsureNativeDllSearchPath();
+                CoreWebView2Environment environment = await Browser.GetOrCreateWebView2EnvironmentAsync();
+
+                // Create an off-screen 1×1 window — needed because WebView2 requires a visual tree
+                hiddenWindow = new Window
+                {
+                    Width = 1,
+                    Height = 1,
+                    Left = -30000,
+                    Top = -30000,
+                    WindowStyle = WindowStyle.None,
+                    ShowInTaskbar = false,
+                    ShowActivated = false,
+                    Title = string.Empty,
+                    Opacity = 0
+                };
+
+                WebView2 webView = new WebView2();
+                hiddenWindow.Content = webView;
+                hiddenWindow.Show();
+
+                await webView.EnsureCoreWebView2Async(environment);
+
+                // Navigate to the temp HTML file and wait for navigation to complete
+                TaskCompletionSource<bool> navigationCompleted = new TaskCompletionSource<bool>();
+
+                void OnNavigationCompleted(object s, CoreWebView2NavigationCompletedEventArgs e)
+                {
+                    webView.NavigationCompleted -= OnNavigationCompleted;
+                    navigationCompleted.TrySetResult(e.IsSuccess);
+                }
+
+                webView.NavigationCompleted += OnNavigationCompleted;
+                webView.CoreWebView2.Navigate(new Uri(tempHtmlFile).AbsoluteUri);
+
+                bool navSuccess = await navigationCompleted.Task;
+                if (!navSuccess)
+                {
+                    throw new InvalidOperationException("Failed to load the HTML content for PDF export.");
+                }
+
+                // Give scripts (Mermaid, Prism, MathJax) a brief moment to render before printing
+                await Task.Delay(300);
+
+                bool printSuccess = await webView.CoreWebView2.PrintToPdfAsync(outputPdfPath);
+                if (!printSuccess)
+                {
+                    throw new InvalidOperationException($"PDF export failed. The browser could not write to: {outputPdfPath}");
+                }
+            }
+            finally
+            {
+                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                hiddenWindow?.Close();
+
+                if (tempHtmlFile != null && File.Exists(tempHtmlFile))
+                {
+                    try { File.Delete(tempHtmlFile); } catch { /* best-effort cleanup */ }
+                }
+            }
+        }
+    }
+}

--- a/src/VSCommandTable.cs
+++ b/src/VSCommandTable.cs
@@ -45,5 +45,6 @@ namespace MarkdownEditor2022
         public const int TogglePreview = 0x1090;
         public const int ToggleSpellChecking = 0x1100;
         public const int GenerateHtml = 0x1110;
+        public const int ExportToPdf = 0x1120;
     }
 }

--- a/src/VSCommandTable.vsct
+++ b/src/VSCommandTable.vsct
@@ -83,6 +83,17 @@
         </Strings>
       </Button>
 
+      <Button guid="MarkdownEditor2022" id="ExportToPdf" priority="160" type="Button">
+        <Parent guid="MarkdownEditor2022" id="PreviewGroup" />
+        <Icon guid="ImageCatalogGuid" id="Print"/>
+        <CommandFlag>IconIsMoniker</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <Strings>
+          <ButtonText>Export to PDF</ButtonText>
+          <LocCanonicalName>.Markdown.ExportToPdf</LocCanonicalName>
+        </Strings>
+      </Button>
+
       <Button guid="MarkdownEditor2022" id="InsertLink" priority="200" type="Button">
         <Parent guid="MarkdownEditor2022" id="EditorGroup" />
         <Icon guid="ImageCatalogGuid" id="AddLink"/>
@@ -165,6 +176,7 @@
     <VisibilityItem guid="MarkdownEditor2022" id="TogglePreview" context="EditorFactory" />
     <VisibilityItem guid="MarkdownEditor2022" id="ToggleSpellChecking" context="EditorFactory" />
     <VisibilityItem guid="MarkdownEditor2022" id="Refresh" context="EditorFactory" />
+    <VisibilityItem guid="MarkdownEditor2022" id="ExportToPdf" context="EditorFactory" />
     <VisibilityItem guid="MarkdownEditor2022" id="ShowKeybindings" context="EditorFactory" />
     <VisibilityItem guid="MarkdownEditor2022" id="ShowMarkdownReference" context="EditorFactory" />
     <VisibilityItem guid="MarkdownEditor2022" id="OpenSettings" context="EditorFactory" />
@@ -204,6 +216,7 @@
       <IDSymbol name="TogglePreview" value="0x1090"/>
       <IDSymbol name="ToggleSpellChecking" value="0x1100"/>
       <IDSymbol name="GenerateHtml" value="0x1110"/>
+      <IDSymbol name="ExportToPdf" value="0x1120"/>
     </GuidSymbol>
   </Symbols>
 </CommandTable>


### PR DESCRIPTION
Add an export to pdf command on right click in a md document: 

<img width="656" height="310" alt="image" src="https://github.com/user-attachments/assets/2309e2f1-686f-4fc1-8cd8-a77e0018f1ab" />


using webview2 renderer and the command https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.core.corewebview2.printtopdfasync?view=webview2-dotnet-1.0.3856.49

It's one of the last reason I need to swap from VS2026 to vscode for md editing, so this would be nice :)
