### PR TITLE
fixes #209 - improve extensionless links

### DIFF
--- a/src/Commands/HtmlGenerationService.cs
+++ b/src/Commands/HtmlGenerationService.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using EnvDTE;
 using Markdig;
 using Markdig.Renderers;
@@ -12,6 +13,9 @@ namespace MarkdownEditor2022
     {
         private const string HtmlTemplateFileName = "md-template.html";
         private const string HtmlExtension = ".html";
+        private static readonly Regex _anchorHrefRegex = new(
+            @"(?<prefix><a\b[^>]*\bhref\s*=\s*"")(?<url>[^""]+)(?<suffix>"")",
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
         public static bool HtmlGenerationEnabled(string markdownFile)
         {
@@ -138,9 +142,55 @@ namespace MarkdownEditor2022
             string markdown = File.ReadAllText(markdownFile);
             MarkdownDocument document = Markdown.Parse(markdown, Document.PipelineToGenerateHtml);
             string content = document.ToHtml(Document.PipelineToGenerateHtml).Replace("\n", Environment.NewLine);
+            content = RewriteRelativeExtensionlessAnchorHrefs(content);
             string title = GetTitle(markdownFile, document);
 
             return CreateFromHtmlTemplate(markdownFile, title, content);
+        }
+
+        internal static string RewriteRelativeExtensionlessAnchorHrefs(string html)
+        {
+            if (string.IsNullOrEmpty(html))
+            {
+                return html;
+            }
+
+            return _anchorHrefRegex.Replace(html, match =>
+            {
+                string href = match.Groups["url"].Value;
+                string rewritten = RewriteHrefIfNeeded(href);
+                if (string.Equals(href, rewritten, StringComparison.Ordinal))
+                {
+                    return match.Value;
+                }
+
+                return string.Concat(match.Groups["prefix"].Value, rewritten, match.Groups["suffix"].Value);
+            });
+        }
+
+        private static string RewriteHrefIfNeeded(string href)
+        {
+            if (string.IsNullOrEmpty(href) ||
+                href.StartsWith("#", StringComparison.Ordinal) ||
+                href.StartsWith("/", StringComparison.Ordinal) ||
+                href.IndexOf(':') >= 0)
+            {
+                return href;
+            }
+
+            int splitIndex = href.IndexOfAny(new[] { '?', '#' });
+            string pathPart = splitIndex >= 0 ? href.Substring(0, splitIndex) : href;
+            string suffix = splitIndex >= 0 ? href.Substring(splitIndex) : string.Empty;
+
+            if (string.IsNullOrEmpty(pathPart) ||
+                pathPart.EndsWith("/", StringComparison.Ordinal) ||
+                pathPart.EndsWith("\\", StringComparison.Ordinal) ||
+                !string.IsNullOrEmpty(Path.GetExtension(pathPart)))
+            {
+                return href;
+            }
+
+            return pathPart + HtmlExtension + suffix;
         }
 
         internal static string CreateFromHtmlTemplate(string markdownFile, string title, string htmlContent)

--- a/src/Margin/Browser.cs
+++ b/src/Margin/Browser.cs
@@ -841,10 +841,57 @@ namespace MarkdownEditor2022
                     }
                 }
             }
+            else
+            {
+                string markdownFallback = TryResolveMissingHtmlToMarkdownSibling(filePath);
+                if (!string.IsNullOrEmpty(markdownFallback))
+                {
+                    if (isLineLink)
+                    {
+                        await OpenAndGoToLineAsync(markdownFallback, targetLine, targetColumn);
+                    }
+                    else
+                    {
+                        if (hasFragment)
+                        {
+                            _pendingFragmentNavigations[Path.GetFullPath(markdownFallback)] = fragment;
+                        }
+
+                        VS.Documents.OpenInPreviewTabAsync(markdownFallback).FireAndForget();
+                    }
+
+                    return;
+                }
+            }
 
             // File doesn't exist - offer to create it if it's a markdown file
             string currentDir = Path.GetDirectoryName(_file);
             await HandleNonExistentMarkdownLinkAsync(filePath, currentDir);
+        }
+
+        internal static string TryResolveMissingHtmlToMarkdownSibling(string filePath, Func<string, bool> fileExists = null)
+        {
+            if (!Path.GetExtension(filePath).Equals(".html", StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            fileExists ??= File.Exists;
+
+            string basePath = Path.Combine(
+                Path.GetDirectoryName(filePath) ?? string.Empty,
+                Path.GetFileNameWithoutExtension(filePath) ?? string.Empty);
+
+            foreach (string ext in _markdownExtensions)
+            {
+                string withExt = basePath + ext;
+                if (fileExists(withExt))
+                {
+                    return withExt;
+                }
+            }
+
+            return null;
         }
 
         /// <summary>

--- a/test/MarkdownEditor2022.UnitTests/FileNavigationTests.cs
+++ b/test/MarkdownEditor2022.UnitTests/FileNavigationTests.cs
@@ -182,6 +182,52 @@ namespace MarkdownEditor2022.UnitTests
             Assert.IsNull(result); // No fallback when extension already present
         }
 
+        [TestMethod]
+        public void TryFindMarkdownSiblingForMissingHtml_FindsMdFile()
+        {
+            string filePath = @"C:\Projects\Docs\aboutpage.html";
+            bool fileExists(string path) => path == @"C:\Projects\Docs\aboutpage.md";
+
+            string result = Browser.TryResolveMissingHtmlToMarkdownSibling(filePath, fileExists);
+
+            Assert.AreEqual(@"C:\Projects\Docs\aboutpage.md", result);
+        }
+
+        [TestMethod]
+        public void TryFindMarkdownSiblingForMissingHtml_PrioritizesMd()
+        {
+            string filePath = @"C:\Projects\Docs\aboutpage.html";
+            bool fileExists(string path) =>
+                path == @"C:\Projects\Docs\aboutpage.md" ||
+                path == @"C:\Projects\Docs\aboutpage.markdown";
+
+            string result = Browser.TryResolveMissingHtmlToMarkdownSibling(filePath, fileExists);
+
+            Assert.AreEqual(@"C:\Projects\Docs\aboutpage.md", result);
+        }
+
+        [TestMethod]
+        public void TryFindMarkdownSiblingForMissingHtml_NoSibling_ReturnsNull()
+        {
+            string filePath = @"C:\Projects\Docs\aboutpage.html";
+            bool fileExists(string path) => false;
+
+            string result = Browser.TryResolveMissingHtmlToMarkdownSibling(filePath, fileExists);
+
+            Assert.IsNull(result);
+        }
+
+        [TestMethod]
+        public void TryFindMarkdownSiblingForMissingHtml_NonHtmlInput_ReturnsNull()
+        {
+            string filePath = @"C:\Projects\Docs\aboutpage.txt";
+            bool fileExists(string path) => true;
+
+            string result = Browser.TryResolveMissingHtmlToMarkdownSibling(filePath, fileExists);
+
+            Assert.IsNull(result);
+        }
+
         #endregion
 
         #region Virtual Host Path Conversion Tests

--- a/test/MarkdownEditor2022.UnitTests/PathResolutionTests.cs
+++ b/test/MarkdownEditor2022.UnitTests/PathResolutionTests.cs
@@ -543,6 +543,60 @@ namespace MarkdownEditor2022.UnitTests
 
         #endregion
 
+        #region HTML Link Rewrite Tests
+
+        [TestMethod]
+        public void RewriteRelativeExtensionlessAnchorHrefs_RelativeNoExtension_AddsHtml()
+        {
+            string html = "<p><a href=\"aboutpage\">About</a></p>";
+
+            string result = HtmlGenerationService.RewriteRelativeExtensionlessAnchorHrefs(html);
+
+            Assert.AreEqual("<p><a href=\"aboutpage.html\">About</a></p>", result);
+        }
+
+        [TestMethod]
+        public void RewriteRelativeExtensionlessAnchorHrefs_RelativeNoExtensionWithFragment_PreservesFragment()
+        {
+            string html = "<p><a href=\"aboutpage#team\">Team</a></p>";
+
+            string result = HtmlGenerationService.RewriteRelativeExtensionlessAnchorHrefs(html);
+
+            Assert.AreEqual("<p><a href=\"aboutpage.html#team\">Team</a></p>", result);
+        }
+
+        [TestMethod]
+        public void RewriteRelativeExtensionlessAnchorHrefs_RelativeNoExtensionWithQuery_PreservesQuery()
+        {
+            string html = "<p><a href=\"aboutpage?lang=en\">About</a></p>";
+
+            string result = HtmlGenerationService.RewriteRelativeExtensionlessAnchorHrefs(html);
+
+            Assert.AreEqual("<p><a href=\"aboutpage.html?lang=en\">About</a></p>", result);
+        }
+
+        [TestMethod]
+        public void RewriteRelativeExtensionlessAnchorHrefs_AbsoluteOrRootOrScheme_Unchanged()
+        {
+            string html = "<p><a href=\"/aboutpage\">Root</a> <a href=\"https://example.com/about\">Web</a> <a href=\"#team\">Anchor</a></p>";
+
+            string result = HtmlGenerationService.RewriteRelativeExtensionlessAnchorHrefs(html);
+
+            Assert.AreEqual(html, result);
+        }
+
+        [TestMethod]
+        public void RewriteRelativeExtensionlessAnchorHrefs_AlreadyHasExtension_Unchanged()
+        {
+            string html = "<p><a href=\"aboutpage.md\">MD</a> <a href=\"aboutpage.html\">HTML</a></p>";
+
+            string result = HtmlGenerationService.RewriteRelativeExtensionlessAnchorHrefs(html);
+
+            Assert.AreEqual(html, result);
+        }
+
+        #endregion
+
         #region URI Scheme Path Resolution Tests
 
         /// <summary>


### PR DESCRIPTION
Fixes #209 end-to-end by rewriting extensionless relative markdown anchor links to  .html  during HTML generation (while preserving query/fragment and leaving root/absolute/scheme links unchanged) and by adding preview fallback so missing  .html  targets open markdown siblings.

