### PR TITLE
fixes #208 - normalize legacy tables

### DIFF
--- a/src/Commands/HtmlGenerationService.cs
+++ b/src/Commands/HtmlGenerationService.cs
@@ -136,7 +136,8 @@ namespace MarkdownEditor2022
             }
 
             string markdown = File.ReadAllText(markdownFile);
-            MarkdownDocument document = Markdown.Parse(markdown, Document.PipelineToGenerateHtml);
+            string normalizedMarkdown = Document.NormalizeMarkdownForParsing(markdown);
+            MarkdownDocument document = Markdown.Parse(normalizedMarkdown, Document.PipelineToGenerateHtml);
             string content = document.ToHtml(Document.PipelineToGenerateHtml).Replace("\n", Environment.NewLine);
             string title = GetTitle(markdownFile, document);
 

--- a/src/Document.cs
+++ b/src/Document.cs
@@ -258,8 +258,15 @@ namespace MarkdownEditor2022
             }
 
             char[] chars = secondLine.ToCharArray();
+            int start = pipeIndex + 1;
+            if (start >= chars.Length || (chars[start] != ' ' && chars[start] != '\t'))
+            {
+                return match.Value;
+            }
+
             int replaced = 0;
-            for (int i = pipeIndex + 1; i < chars.Length; i++)
+            int replaceFrom = (start + 1 < chars.Length) ? start + 1 : start;
+            for (int i = replaceFrom; i < chars.Length; i++)
             {
                 if (chars[i] == ' ' || chars[i] == '\t')
                 {

--- a/src/Document.cs
+++ b/src/Document.cs
@@ -46,6 +46,9 @@ namespace MarkdownEditor2022
         // Handles both ":::mermaid" and "::: mermaid" (with space) formats
         // Uses a MatchEvaluator to exclude markdown alerts like "::: note"
         private static readonly Regex _colonFixRegex = new(@"^(:::) ?(\w*)", RegexOptions.Multiline | RegexOptions.Compiled);
+        private static readonly Regex _legacyPipeTableRegex = new(
+            @"(?m)^(?<indent>[ \t]*)\|[^\r\n]*\r?\n(?<second>\k<indent>\|[ \t]+)\r?\n\k<indent>\|[^\r\n]*",
+            RegexOptions.Compiled);
         private static readonly HashSet<string> _alertKeywords = new(StringComparer.OrdinalIgnoreCase)
         {
             "note", "tip", "important", "caution", "warning"
@@ -138,9 +141,7 @@ namespace MarkdownEditor2022
                         return;
                     }
 
-                    // This fixes this bug: https://github.com/madskristensen/MarkdownEditor2022/issues/128
-                    // Also supports ::: mermaid syntax (with space): https://github.com/madskristensen/MarkdownEditor2022/issues/170
-                    text = _colonFixRegex.Replace(text, ColonFixEvaluator);
+                    text = NormalizeMarkdownForParsing(text);
 
                     MarkdownDocument md = Markdig.Markdown.Parse(text, Pipeline);
 
@@ -227,6 +228,60 @@ namespace MarkdownEditor2022
 
             // Convert ::: or ::: <keyword> to ``` or ```<keyword>
             return "```" + keyword;
+        }
+
+        internal static string NormalizeMarkdownForParsing(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return text;
+            }
+
+            // This fixes this bug: https://github.com/madskristensen/MarkdownEditor2022/issues/128
+            // Also supports ::: mermaid syntax (with space): https://github.com/madskristensen/MarkdownEditor2022/issues/170
+            text = _colonFixRegex.Replace(text, ColonFixEvaluator);
+
+            // Compatibility for legacy markdown where pipe-table separator line is just "|   ".
+            // Keep text length unchanged so AST spans still map back to editor buffer positions.
+            // see: https://github.com/madskristensen/MarkdownEditor2022/issues/208
+            return _legacyPipeTableRegex.Replace(text, LegacyPipeTableEvaluator);
+        }
+
+        private static string LegacyPipeTableEvaluator(Match match)
+        {
+            Group secondGroup = match.Groups["second"];
+            string secondLine = secondGroup.Value;
+            int pipeIndex = secondLine.IndexOf('|');
+            if (pipeIndex < 0 || pipeIndex + 1 >= secondLine.Length)
+            {
+                return match.Value;
+            }
+
+            char[] chars = secondLine.ToCharArray();
+            int replaced = 0;
+            for (int i = pipeIndex + 1; i < chars.Length; i++)
+            {
+                if (chars[i] == ' ' || chars[i] == '\t')
+                {
+                    chars[i] = '-';
+                    replaced++;
+                    if (replaced == 3)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            if (replaced > 0)
+            {
+                string updatedSecondLine = new(chars);
+                int relativeStart = secondGroup.Index - match.Index;
+                return match.Value.Substring(0, relativeStart)
+                       + updatedSecondLine
+                       + match.Value.Substring(relativeStart + secondLine.Length);
+            }
+
+            return match.Value;
         }
 
         private void AdvancedOptionsSaved(AdvancedOptions obj)

--- a/src/Editor/IntelliSense.cs
+++ b/src/Editor/IntelliSense.cs
@@ -423,7 +423,8 @@ namespace MarkdownEditor2022
                 result = await Task.Run(() =>
                 {
                     string text = File.ReadAllText(targetPath);
-                    return (Markdig.Markdown.Parse(text, Document.Pipeline), text);
+                    string normalizedText = Document.NormalizeMarkdownForParsing(text);
+                    return (Markdig.Markdown.Parse(normalizedText, Document.Pipeline), text);
                 });
             }
             catch

--- a/test/MarkdownEditor2022.UnitTests/LegacyTableCompatibilityTests.cs
+++ b/test/MarkdownEditor2022.UnitTests/LegacyTableCompatibilityTests.cs
@@ -1,0 +1,29 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MarkdownEditor2022.UnitTests
+{
+    [TestClass]
+    public class LegacyTableCompatibilityTests
+    {
+        [TestMethod]
+        public void LegacyPipeTableSeparatorWithSpaces_NormalizationKeepsLength()
+        {
+            string input = "| This is a table.\n|    \n| Item 1\n| Item 2";
+
+            string normalized = Document.NormalizeMarkdownForParsing(input);
+
+            Assert.AreEqual(input.Length, normalized.Length);
+            Assert.Contains("| ---", normalized, "Blank legacy separator line should become a valid separator.");
+        }
+
+        [TestMethod]
+        public void ExistingPipeTableSeparator_IsUnchanged()
+        {
+            string input = "| Name |\n| --- |\n| Value |";
+
+            string normalized = Document.NormalizeMarkdownForParsing(input);
+
+            Assert.AreEqual(input, normalized);
+        }
+    }
+}

--- a/test/MarkdownEditor2022.UnitTests/MarkdownEditor2022.UnitTests.csproj
+++ b/test/MarkdownEditor2022.UnitTests/MarkdownEditor2022.UnitTests.csproj
@@ -48,6 +48,7 @@
     <Compile Include="FrontMatterTests.cs" />
     <Compile Include="JavaScriptEscapeTests.cs" />
     <Compile Include="LanguageAliasTests.cs" />
+    <Compile Include="LegacyTableCompatibilityTests.cs" />
     <Compile Include="MermaidClassConversionTests.cs" />
     <Compile Include="PasteImageCommandTests.cs" />
     <Compile Include="PathResolutionTests.cs" />


### PR DESCRIPTION
fixes #208 by adding shared legacy pipe-table normalization ( `|     ` →  `| ---` ) across parsing paths.