### PR TITLE
fixes #227 - fallback to a safe loading of commands

### DIFF
--- a/src/ExtensionMethods.cs
+++ b/src/ExtensionMethods.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Markdig.Syntax;
@@ -35,5 +37,45 @@ namespace MarkdownEditor2022
             await task; // Propagate exceptions
         }
 #pragma warning restore VSTHRD003
+
+        /// <summary>
+        /// Registers commands from a collection of loadable types, bypassing types that failed metadata loading.
+        /// </summary>
+        public static async Task RegisterCommandsFromTypesAsync(this ToolkitPackage package, IEnumerable<Type> types)
+        {
+            if (package == null)
+            {
+                throw new ArgumentNullException(nameof(package));
+            }
+
+            if (types == null)
+            {
+                return;
+            }
+
+            foreach (Type type in types)
+            {
+                if (type?.IsAbstract != false || !type.IsClass)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    MethodInfo method = type.GetMethod(
+                        nameof(BaseCommand<>.InitializeAsync),
+                        BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
+
+                    if (method?.Invoke(null, [package]) is Task task)
+                    {
+                        await task;
+                    }
+                }
+                catch (Exception cmdEx)
+                {
+                    await cmdEx.LogAsync();
+                }
+            }
+        }
     }
 }

--- a/src/MarkdownEditor2022.csproj
+++ b/src/MarkdownEditor2022.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
@@ -16,6 +16,8 @@
     <VsixDeployOnDebug>true</VsixDeployOnDebug>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
     <UseCodebase>true</UseCodebase>
+    <!-- Ignoring CVST005 as it is not compatible with try/catch wrapping of RegisterCommandsAsync - see #227 -->
+    <NoWarn>$(NoWarn);CVST005</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MarkdownEditor2022Package.cs
+++ b/src/MarkdownEditor2022Package.cs
@@ -4,6 +4,8 @@ global using Microsoft.VisualStudio.Shell;
 global using Task = System.Threading.Tasks.Task;
 using System.ComponentModel.Design;
 using System.IO;
+using System.Linq;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
 using EnvDTE;
@@ -64,7 +66,19 @@ namespace MarkdownEditor2022
             RegisterEditorFactory(language);
             ((IServiceContainer)this).AddService(typeof(MarkdownEditorV2), language, true);
 
-            await this.RegisterCommandsAsync();
+            try
+            {
+                await this.RegisterCommandsAsync();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                await ex.LogAsync();
+                await this.RegisterCommandsFromTypesAsync(ex.Types.Where(t => t != null));
+            }
+            catch (Exception ex)
+            {
+                await ex.LogAsync();
+            }
             await Commenting.InitializeAsync();
             await ToggleTaskCommand.InitializeAsync();
             await FormatTableCommand.InitializeAsync();

--- a/test/MarkdownEditor2022.UnitTests/ReflectionTypeLoadExceptionTests.cs
+++ b/test/MarkdownEditor2022.UnitTests/ReflectionTypeLoadExceptionTests.cs
@@ -1,0 +1,63 @@
+using System.Reflection;
+using Community.VisualStudio.Toolkit;
+
+namespace MarkdownEditor2022.UnitTests
+{
+    [TestClass]
+    public class ReflectionTypeLoadExceptionTests
+    {
+        [TestMethod]
+        public void WhenAssemblyGetTypesThrowsReflectionTypeLoadExceptionThenGetLoadableTypesReturnsNonNullTypes()
+        {
+            Assembly assembly = typeof(ExtensionMethods).Assembly;
+
+            // Verify GetLoadableTypes returns non-null types for a healthy assembly
+            Type[] types = GetLoadableTypes(assembly).ToArray();
+            Assert.IsTrue(types.Length > 0);
+            Assert.IsTrue(types.Contains(typeof(ExtensionMethods)));
+            Assert.IsFalse(types.Any(t => t == null));
+        }
+
+        private static IEnumerable<Type> GetLoadableTypes(Assembly assembly)
+        {
+            try
+            {
+                return assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                return ex.Types.Where(t => t != null);
+            }
+        }
+
+        [TestMethod]
+        public void WhenFindingInitializeAsyncMethodOnCommandTypeThenGetMethodReturnsMethodInfo()
+        {
+            Type commandType = typeof(GenerateTocCommand);
+
+            MethodInfo method = commandType.GetMethod(
+                nameof(BaseCommand<object>.InitializeAsync),
+                BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
+
+            Assert.IsNotNull(method);
+            Assert.AreEqual("InitializeAsync", method.Name);
+            Assert.IsTrue(method.IsStatic);
+        }
+
+        [TestMethod]
+        public void WhenReflectionTypeLoadExceptionHasNullTypesThenFilterRemovesNulls()
+        {
+            Type?[] mockTypes = [typeof(string), null, typeof(int), null, typeof(bool)];
+            Exception[] mockExceptions = [new("Mock loader exception")];
+
+            ReflectionTypeLoadException ex = new(mockTypes, mockExceptions);
+
+            Type[] validTypes = ex.Types.Where(t => t != null).ToArray();
+
+            Assert.AreEqual(3, validTypes.Length);
+            Assert.AreEqual(typeof(string), validTypes[0]);
+            Assert.AreEqual(typeof(int), validTypes[1]);
+            Assert.AreEqual(typeof(bool), validTypes[2]);
+        }
+    }
+}


### PR DESCRIPTION
fixes #227 - fallback to a safe loading without the burden of listing all commands.