### PR TITLE
fixes #205 - Headers normalization for edge cases + Markdig updated to 1.3.2 / MSTest 4.4.0

### DIFF
--- a/src/Commands/HtmlGenerationService.cs
+++ b/src/Commands/HtmlGenerationService.cs
@@ -141,6 +141,7 @@ namespace MarkdownEditor2022
 
             string markdown = File.ReadAllText(markdownFile);
             MarkdownDocument document = Markdown.Parse(markdown, Document.PipelineToGenerateHtml);
+            Document.NormalizeHeadingIds(document);
             string content = document.ToHtml(Document.PipelineToGenerateHtml).Replace("\n", Environment.NewLine);
             content = RewriteRelativeExtensionlessAnchorHrefs(content);
             string title = GetTitle(markdownFile, document);

--- a/src/Document.cs
+++ b/src/Document.cs
@@ -1,11 +1,14 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Markdig;
 using Markdig.Extensions.AutoIdentifiers;
+using Markdig.Renderers.Html;
 using Markdig.Extensions.Tables;
 using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
 using MarkdownEditor2022.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Threading;
@@ -143,6 +146,7 @@ namespace MarkdownEditor2022
                     text = _colonFixRegex.Replace(text, ColonFixEvaluator);
 
                     MarkdownDocument md = Markdig.Markdown.Parse(text, Pipeline);
+                    NormalizeHeadingIds(md);
 
                     if (localToken.IsCancellationRequested)
                     {
@@ -184,6 +188,48 @@ namespace MarkdownEditor2022
             {
                 _parseSemaphore.Release();
             }
+        }
+
+        internal static void NormalizeHeadingIds(MarkdownDocument document)
+        {
+            HashSet<string> identifiers = [.. document.Descendants<HeadingBlock>()
+                    .Select(heading => heading.GetAttributes().Id)
+                    .Where(id => id != null)];
+
+            foreach (HeadingBlock heading in document.Descendants<HeadingBlock>())
+            {
+                string id = heading.GetAttributes().Id;
+                if (id != null &&
+                    heading.Inline?.Descendants<HtmlInline>().Any() == true &&
+                    !heading.Lines.ToString().Contains("{#", StringComparison.Ordinal))
+                {
+                    string baseId = id.EndsWith("-", StringComparison.Ordinal)
+                        ? id.TrimEnd('-')
+                        : NormalizeDuplicateIdentifier(id);
+                    if (string.Equals(baseId, id, StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    identifiers.Remove(id);
+                    string normalizedId = baseId;
+                    int suffix = 0;
+                    while (!identifiers.Add(normalizedId))
+                    {
+                        normalizedId = $"{baseId}-{++suffix}";
+                    }
+
+                    heading.GetAttributes().Id = normalizedId;
+                }
+            }
+        }
+
+        private static string NormalizeDuplicateIdentifier(string id)
+        {
+            int separator = id.LastIndexOf("--", StringComparison.Ordinal);
+            return separator >= 0 && int.TryParse(id.Substring(separator + 2), out _)
+                ? id.Remove(separator, 1)
+                : id;
         }
 
         private static DocumentAnalysis BuildAnalysis(MarkdownDocument md)

--- a/src/MarkdownEditor2022.csproj
+++ b/src/MarkdownEditor2022.csproj
@@ -137,7 +137,7 @@
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="18.5.40034" PrivateAssets="all" />
-    <PackageReference Include="Markdig" Version="1.1.2" IncludeAssets="all" />
+    <PackageReference Include="Markdig" Version="1.3.2" IncludeAssets="all" />
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3485.44" />
   </ItemGroup>
 

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -8,7 +8,7 @@ using MarkdownEditor2022;
 [assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.Web.WebView2.Wpf", OldVersionLowerBound = "0.0.0.0", OldVersionUpperBound = "1.0.3485.44", NewVersion = "1.0.3485.44")]
 
 // Binding redirect for Markdig
-[assembly: ProvideBindingRedirection(AssemblyName = "Markdig", OldVersionLowerBound = "0.0.0.0", OldVersionUpperBound = "1.1.0.0", NewVersion = "1.1.0.0")]
+[assembly: ProvideBindingRedirection(AssemblyName = "Markdig", OldVersionLowerBound = "0.0.0.0", OldVersionUpperBound = "1.3.0.0", NewVersion = "1.3.0.0")]
 
 // Binding redirects for Markdig transitive dependencies (System.Memory and friends)
 [assembly: ProvideBindingRedirection(AssemblyName = "System.Memory", OldVersionLowerBound = "0.0.0.0", OldVersionUpperBound = "4.0.5.0", NewVersion = "4.0.5.0")]

--- a/test/MarkdownEditor2022.UnitTests/MarkdownEditor2022.UnitTests.csproj
+++ b/test/MarkdownEditor2022.UnitTests/MarkdownEditor2022.UnitTests.csproj
@@ -10,7 +10,7 @@
     <AssemblyName>MarkdownEditor2022.UnitTests</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MSTest" Version="4.3.3" />
+    <PackageReference Include="MSTest" Version="4.4.0" />
 
     <!--
       MarkdownEditor2022.csproj excludes the Visual Studio runtime assemblies because the IDE supplies them.

--- a/test/MarkdownEditor2022.UnitTests/SlugGeneratorTests.cs
+++ b/test/MarkdownEditor2022.UnitTests/SlugGeneratorTests.cs
@@ -12,12 +12,7 @@ namespace MarkdownEditor2022.UnitTests
     [TestClass]
     public class SlugGeneratorTests
     {
-        // Pipeline matching the app configuration in Document.cs
-        // UseAutoIdentifiers(GitHub) must come BEFORE UseAdvancedExtensions
-        private static readonly MarkdownPipeline _pipeline = new MarkdownPipelineBuilder()
-            .UseAutoIdentifiers(AutoIdentifierOptions.GitHub)
-            .UseAdvancedExtensions()
-            .Build();
+        private static readonly MarkdownPipeline _pipeline = Document.PipelineToGenerateHtml;
 
         /// <summary>
         /// Parses markdown and returns the generated heading ID.
@@ -129,6 +124,63 @@ namespace MarkdownEditor2022.UnitTests
             string result = GetHeadingId("## [HTML], [S5], or [RTF]?");
 
             Assert.AreEqual("html-s5-or-rtf", result);
+        }
+
+        [TestMethod]
+        public void GetHeadingId_Issue205IconHeadings_DoNotEndWithHyphen()
+        {
+            string markdown = """
+                ### Flyout (<u>&#xF035C;</u>)
+
+                ### Use (<u>&#xF02FA;</u>)
+
+                ### Add (<u>&#xF0419;</u>)
+                """;
+
+            MarkdownDocument doc = Markdown.Parse(markdown, _pipeline);
+            Document.NormalizeHeadingIds(doc);
+            List<HeadingBlock> headings = doc.Descendants<HeadingBlock>().ToList();
+
+            Assert.AreEqual(
+                "flyout\nuse\nadd",
+                string.Join("\n", headings.Select(heading => heading.GetAttributes().Id)));
+        }
+
+        [TestMethod]
+        public void GetHeadingId_LiteralTrailingHyphen_IsPreserved()
+        {
+            MarkdownDocument doc = Markdown.Parse("### Release-", _pipeline);
+            Document.NormalizeHeadingIds(doc);
+            string result = doc.Descendants<HeadingBlock>().First().GetAttributes().Id ?? string.Empty;
+
+            Assert.AreEqual("release-", result);
+        }
+
+        [TestMethod]
+        public void GetHeadingId_CustomTrailingHyphen_IsPreserved()
+        {
+            MarkdownDocument doc = Markdown.Parse("### Release {#release-}", _pipeline);
+            Document.NormalizeHeadingIds(doc);
+            string result = doc.Descendants<HeadingBlock>().First().GetAttributes().Id ?? string.Empty;
+
+            Assert.AreEqual("release-", result);
+        }
+
+        [TestMethod]
+        public void GetHeadingId_DuplicateIssue205IconHeadings_RemainUnique()
+        {
+            string markdown = """
+                ### Flyout (<u>&#xF035C;</u>)
+
+                ### Flyout (<u>&#xF035C;</u>)
+                """;
+
+            MarkdownDocument doc = Markdown.Parse(markdown, _pipeline);
+            Document.NormalizeHeadingIds(doc);
+            List<HeadingBlock> headings = doc.Descendants<HeadingBlock>().ToList();
+
+            Assert.AreEqual("flyout", headings[0].GetAttributes().Id);
+            Assert.AreEqual("flyout-1", headings[1].GetAttributes().Id);
         }
 
         [TestMethod]


### PR DESCRIPTION
fixes #205 - updated Markdig (repro test was still failing) / MSTest  and added normalization for headers